### PR TITLE
Fix retrieving chromedriver version with newline

### DIFF
--- a/tasks/selenium_plugin.js
+++ b/tasks/selenium_plugin.js
@@ -143,8 +143,9 @@ function update_chrome_driver_details(){
         var req = http.get('http://chromedriver.storage.googleapis.com/LATEST_RELEASE', function(res) {
             res.setEncoding('utf8');
             res.on('data', function (chunk) {
-                console.log('Latest Release of Chrome driver is: ' + chunk);
-                chrome_driver_details.version = chunk;
+                var version = chunk.trim();
+                console.log('Latest Release of Chrome driver is: ' + version);
+                chrome_driver_details.version = version;
                 deferred.resolve();
             });
         });


### PR DESCRIPTION
The URL for retrieving the latest chromedriver version was retrieving a
version number with "\n" appended. This resulted in an invalid
chromedriver download URL being used.

The chromedriver version is now trimmed.
